### PR TITLE
add default WILDS org files for contributing, issues, PRs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,126 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at {{{ contact }}}. 
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][https://github.com/mozilla/inclusion].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+This outlines how to propose a change to usethis. 
+For more detailed info about contributing to this, and other WILDS projects, please see the
+[**WILDS Contributing Guide**](https://getwilds.org/guide/). 
+
+## Fixing typos/docs changes
+
+You can fix typos, spelling mistakes, or grammatical errors in the documentation directly using the GitHub web interface, as long as the changes are made in the _source_ file. 
+
+## Bigger changes
+
+If you want to make a bigger change, it's a good idea to first file an issue and make sure someone from the team agrees that it’s needed. 
+
+If you’ve found a bug, please file an issue that illustrates the bug with a minimal 
+reproducible example ([reprex](https://www.tidyverse.org/help/#reprex) for R, or [reprexpy](https://github.com/crew102/reprexpy) for Python).
+
+### Pull request process
+
+*   Fork the package and clone onto your computer
+*   Create a Git branch for your pull request (PR)
+*   Make your changes, commit to git, and then create a pull request.
+    *   The title of your PR should briefly describe the change.
+    *   The body of your PR should contain `Fixes #issue-number`.
+*  For user-facing changes, add a bullet to the changelog file if there is one. This should be `NEWS.md` for an R package, and likely `Changelog.md` or `Changelog.rst` for a Python package.
+
+### Code style
+
+*   New code for R and Python packages should follow our [style guide](https://getwilds.org/guide/style.html). 
+
+## Code of Conduct
+
+Please note that this project is released with a
+[Contributor Code of Conduct](CODE_OF_CONDUCT.md). By contributing to this
+project you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,7 @@
+<!-- 
+Maintainers: This issue template comes from https://github.com/getwilds/.github
+You're encouraged to add your own that's optimized for your repo -->
+
 # Contributing
 
 This outlines how to propose a change to usethis. 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,14 @@
+---
+name: Bug report or feature request
+about: Describe a bug you've seen or make a case for a new feature
+---
+
+Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask in the Fred Hutch Data Slack <https://join.slack.com/t/fhdata/signup>.
+
+Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
+
+Brief description of the problem
+
+```r
+# insert reprex here
+```

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@ name: Bug report or feature request
 about: Describe a bug you've seen or make a case for a new feature
 ---
 
-Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask in the Fred Hutch Data Slack <https://hutchdatascience.org/joinslack/>.
+Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask in the Fred Hutch Data Slack <https://hutchdatascience.org/joinslack/> or email us at <wilds@fredhutch.org>.
 
 Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
 

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,8 +3,12 @@ name: Bug report or feature request
 about: Describe a bug you've seen or make a case for a new feature
 ---
 
+<!-- 
+Maintainers: This issue template comes from https://github.com/getwilds/.github
+You're encouraged to add your own that's optimized for your repo -->
+
 Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask in the Fred Hutch Data Slack <https://hutchdatascience.org/joinslack/> or email us at <wilds@fredhutch.org>.
 
-Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
+Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) start by reading <https://www.tidyverse.org/help/#reprex>
 
 Brief description of the problem:

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -3,12 +3,8 @@ name: Bug report or feature request
 about: Describe a bug you've seen or make a case for a new feature
 ---
 
-Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask in the Fred Hutch Data Slack <https://join.slack.com/t/fhdata/signup>.
+Please briefly describe your problem and what output you expect. If you have a question, please don't use this form. Instead, ask in the Fred Hutch Data Slack <https://hutchdatascience.org/joinslack/>.
 
 Please include a minimal reproducible example (AKA a reprex). If you've never heard of a [reprex](http://reprex.tidyverse.org/) before, start by reading <https://www.tidyverse.org/help/#reprex>.
 
-Brief description of the problem
-
-```r
-# insert reprex here
-```
+Brief description of the problem:

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+<!--- Provide a general summary of your changes in the Title above -->
+
+## Description
+<!--- Describe your changes -->
+
+## Related Issue
+<!--- if this closes an issue make sure include e.g., "fix #4"
+or similar - or if just relates to an issue make sure to mention
+it like "#4" -->
+
+## Example
+<!--- if introducing a new feature or changing behavior of existing
+methods/functions, include a brief example if possible -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,7 @@
+<!-- 
+Maintainers: This issue template comes from https://github.com/getwilds/.github
+You're encouraged to add your own that's optimized for your repo -->
+
 <!--- Provide a general summary of your changes in the Title above -->
 
 ## Description

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
 # .github
+
+Default community health files for the WILDS.


### PR DESCRIPTION
Docs on org wide community health files https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file

this comes via https://github.com/getwilds/guide/pull/20/files/f99937caf83b835e9fc9ca9ce8c77c06ea9f3758#diff-25ae72a23eb4c5264137761d8eafac2d66152b6699d0dbb54f191bbaa3c47931 

I opened this as a DRAFT PR to emphasize that this is just a proposal. 

Note that

- the community health files can be at the top level of this repo, or within `.github` within this repo
- any repo in getwilds that adds their own file of the same name will override these default files
- i think we want to encourage people to specify their own files that are more specific to their use case

## Maybe 
- we should include text in each of these that they come from this repo? 
- remind the maintainer of the repo reading these files that they can make their own?
