### PR TITLE
Use a new delete bot comments setup

### DIFF
--- a/workflow-templates/deploy-preview.yml
+++ b/workflow-templates/deploy-preview.yml
@@ -1,23 +1,43 @@
 on:
   pull_request:
-    branches: [ $default-branch ]
+    branches: [$default-branch]
   issue_comment:
-    types: [ created ]
+    types: [created]
 
 name: Quarto Deploy Preview
 
 jobs:
   delete-bot-comments:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - name: pr-deleter
-        uses: maheshrayas/action-pr-comment-delete@v3.0
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Delete bot comments
+        uses: actions/github-script@v7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          org: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
-          user: 'github-actions[bot]'
-          issue: ${{ github.event.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+
+            const botUsername = 'github-actions[bot]';
+            for (const comment of comments) {
+              if (comment.user.login === botUsername) {
+                console.log(`Deleting comment ${comment.id}`);
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: comment.id
+                });
+              }
+            }
 
   build-deploy-preview:
     # Deploy a preview only if
@@ -25,7 +45,7 @@ jobs:
     # - the PR is not from a fork
     if: |
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true)
-
+    needs: delete-bot-comments
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -54,7 +74,7 @@ jobs:
           NETLIFY_SITE_ID: <your netlify id>
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         with:
-          publish-dir: './_site'
+          publish-dir: "./_site"
           production-deploy: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: |


### PR DESCRIPTION
fix #8 

- old action we were using for unknown reasons is no longer working. 
- use javascript script to do the old comment deletes

this new setup is working in sixtyfour, a PR here https://github.com/getwilds/sixtyfour/pull/107 and the yml file only on `dev` branch here https://github.com/getwilds/sixtyfour/blob/dev/.github/workflows/pkgdown.yaml#L14 

apologies, there's some WS changes zed introduced I didn't catch